### PR TITLE
Update pyodbc to version 4.0.32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyodbc" %}
-{% set version = "4.0.31" %}
-{% set sha256 = "3ea585444c13fdf7e9d50651deff1be5d37fdb9d46a6c885e798baf0ee0165dc" %}
+{% set version = "4.0.32" %}
+{% set sha256 = "4ed213d0f67d639d03d37de52a613a4e5a0da113e6d0d56e90dca09d7060470c" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     - pyodbc
   requires:
     - pip
-    - python <3.10
+    - python
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     - setup.patch  # [unix]
 
 build:
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -34,13 +35,14 @@ requirements:
     - unixodbc   # [unix]
     - wheel
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
     - pyodbc
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
  pyodbc 4.0.32
1. check the upstream
    https://github.com/mkleehammer/pyodbc/tree/4.0.32

2. check the pinnings
    https://github.com/mkleehammer/pyodbc/blob/4.0.32/setup.py
    https://github.com/mkleehammer/pyodbc/blob/4.0.32/notes.txt

3. check the changelogs

4. additional research
    http://github.com/conda-forge/pyodbc-feedstock/issues

    There are currently no open issues mentioned in `conda-forge` at the time of the 
    review.

5. verify dev_url
    https://github.com/mkleehammer/pyodbc

6. verify doc_url
    http://mkleehammer.github.io/pyodbc/

7. pip in the test section
8. veriy the test section
9. additional tests
  
In order to test the `pyodbc` package version `4.0.32` the folowing
command was used: 
`conda build pyodbc-feedstock --test`
the test result was the following:
 `All tests passed`
 
Based on the research findings and the test results we can conclude
that it is safe to update `pyodbc` to version `4.0.32`
