### PR TITLE
build pyodbc version 4.0.32 for linux-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - setup.patch  # [unix]
 
 build:
-  skip: True  # [py<37]
+  # skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -35,7 +35,7 @@ requirements:
     - unixodbc   # [unix]
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ source:
     - setup.patch  # [unix]
 
 build:
-  # skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 


### PR DESCRIPTION
correct the issue of the missing build on linux-64