### PR TITLE
Rebuild pyodbc 4.0.32 for python 3.10 support

### DIFF
--- a/recipe/0001-Comment-out-fix-for-663.patch
+++ b/recipe/0001-Comment-out-fix-for-663.patch
@@ -1,0 +1,31 @@
+From 86f600359b33c4e0583a59b1c701faa2c3cc850b Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Sun, 8 Mar 2020 21:09:10 -0400
+Subject: [PATCH] Comment out fix for #663
+
+FH4(-) is a VS2019+ flag, throws C1007 with VS2015
+---
+ setup.py | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index bc97bec..998a534 100755
+--- a/setup.py
++++ b/setup.py
+@@ -168,9 +168,10 @@ def get_compiler_settings(version_str):
+         # made the settings.
+         # https://lectem.github.io/msvc/reverse-engineering/build/2019/01/21/MSVC-hidden-flags.html
+ 
+-        if sys.hexversion >= 0x03050000:
+-            settings['extra_compile_args'].append('/d2FH4-')
+-            settings['extra_link_args'].append('/d2:-FH4-')
++        # Uncomment below when using VS2019
++        # if sys.hexversion >= 0x03050000:
++            # settings['extra_compile_args'].append('/d2FH4-')
++            # settings['extra_link_args'].append('/d2:-FH4-')
+ 
+         settings['libraries'].append('odbc32')
+         settings['libraries'].append('advapi32')
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyodbc" %}
 {% set version = "4.0.32" %}
-{% set sha256 = "4ed213d0f67d639d03d37de52a613a4e5a0da113e6d0d56e90dca09d7060470c" %}
+{% set sha256 = "9be5f0c3590655e1968488410fe3528bb8023d527e7ccec1f663d64245071a6b" %}
 
 package:
   name: {{ name|lower }}
@@ -8,15 +8,14 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  # no sdict was uploaded to PyPI for the 4.0.30 release, use the GitHub archive.
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  url: https://github.com/mkleehammer/pyodbc/archive/{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - setup.patch  # [unix]
+    - 0001-Comment-out-fix-for-663.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -24,9 +23,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - git
-    - patch  # [not win]
+    - patch     # [not win]
     - m2-patch  # [win]
-
   host:
     - python
     - pip
@@ -41,7 +39,6 @@ test:
     - pyodbc
   requires:
     - pip
-    - python
   commands:
     - pip check
 
@@ -50,12 +47,12 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: 'DB API Module for ODBC'
+  summary: DB API Module for ODBC
   description: |
     pyodbc is a Python DB API 2 module for ODBC. This project provides an
     up-to-date, convenient interface to ODBC using native data types like
     datetime and decimal.
-  doc_url: http://mkleehammer.github.io/pyodbc/
+  doc_url: https://mkleehammer.github.io/pyodbc/
   doc_source_url: https://github.com/mkleehammer/pyodbc/blob/master/docs/index.md
   dev_url: https://github.com/mkleehammer/pyodbc
 


### PR DESCRIPTION
License: https://github.com/mkleehammer/pyodbc/blob/4.0.32/LICENSE.txt
Install:  https://github.com/mkleehammer/pyodbc/wiki/Install
Requirements: https://github.com/mkleehammer/pyodbc/blob/4.0.32/setup.py

Actions:
1. Update source/url
2. Add a patch
3. Bump build number
4. Remove python from test/requires
5. Fix doc_url with HTTPS