### PR TITLE
pyodbc 4.0.34

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyodbc" %}
-{% set version = "4.0.32" %}
-{% set sha256 = "9be5f0c3590655e1968488410fe3528bb8023d527e7ccec1f663d64245071a6b" %}
+{% set version = "4.0.34" %}
+{% set sha256 = "7ea7869532b96b8d529b1f08ea85765f94df7e4a58e968b2f8d455346a03e45c" %}
 
 package:
   name: {{ name|lower }}
@@ -15,7 +15,7 @@ source:
     - 0001-Comment-out-fix-for-663.patch
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -44,7 +44,7 @@ test:
 
 about:
   home: https://github.com/mkleehammer/pyodbc
-  license: MIT
+  license: MIT-0
   license_family: MIT
   license_file: LICENSE.txt
   summary: DB API Module for ODBC

--- a/recipe/setup.patch
+++ b/recipe/setup.patch
@@ -1,13 +1,22 @@
-diff --git setup.py setup.py
-index 2844bad..04f6431 100755
---- setup.py
-+++ setup.py
-@@ -117,7 +117,7 @@ def get_compiler_settings(version_str):
-     settings = {
+diff --git a/setup.py b/setup.py
+index 260ce7d..940ca1c 100755
+--- a/setup.py
++++ b/setup.py
+@@ -135,7 +135,7 @@ def get_compiler_settings(version_str):
          'extra_compile_args' : [],
+         'extra_link_args': [],
          'libraries': [],
 -        'include_dirs': [],
 +        'include_dirs': [join(sys.prefix, 'include')],
          'define_macros' : [ ('PYODBC_VERSION', version_str) ]
      }
  
+@@ -197,7 +197,7 @@ def get_compiler_settings(version_str):
+ 
+         # Homebrew installs odbc_config
+         pipe = os.popen('odbc_config --cflags --libs 2>/dev/null')
+-        cflags, ldflags = pipe.readlines()
++        cflags, ldflags = pipe.readlines() or (None, None)
+         exit_status = pipe.close()
+ 
+         if exit_status is None:


### PR DESCRIPTION
License: https://github.com/mkleehammer/pyodbc/blob/4.0.34/LICENSE.txt
Changelog: https://github.com/mkleehammer/pyodbc/releases
Requirements: https://github.com/mkleehammer/pyodbc/blob/4.0.34/setup.py

Actions:
1. Update `setup.patch`
2. Reset build number to `0`
3. Fix license name, see https://github.com/mkleehammer/pyodbc/blob/4.0.34/LICENSE.txt and https://spdx.org/licenses/